### PR TITLE
Fixing the script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -50,7 +50,6 @@ Write-Host $arch
 Write-Host $downloadURL
 Write-Host "Downloading komocli package..."
 Invoke-WebRequest -Uri $downloadURL -OutFile "komocli.exe"
-#Write-Host "Installing komocli..."
-#Move-Item -Path "komocli.exe" -Destination $env:APPDATA
-#Remove-Item -Path "komocli_${version}_${os}_${arch}.exe"
-#Write-Host "komocli installation completed!"
+Write-Host "Installing komocli..."
+Move-Item -Path "komocli.exe" -Destination $env:APPDATA
+Write-Host "komocli installation completed!"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -49,7 +49,7 @@ Write-Host $os
 Write-Host $arch
 Write-Host $downloadURL
 Write-Host "Downloading komocli package..."
-Invoke-WebRequest -Uri $downloadURL -OutFile "komocli_${version}_${os}_${arch}.exe"
+Invoke-WebRequest -Uri $downloadURL -OutFile "komocli.exe"
 Write-Host "Installing komocli..."
 Move-Item -Path "komocli.exe" -Destination $env:APPDATA
 Remove-Item -Path "komocli_${version}_${os}_${arch}.exe"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -50,7 +50,7 @@ Write-Host $arch
 Write-Host $downloadURL
 Write-Host "Downloading komocli package..."
 Invoke-WebRequest -Uri $downloadURL -OutFile "komocli.exe"
-Write-Host "Installing komocli..."
-Move-Item -Path "komocli.exe" -Destination $env:APPDATA
-Remove-Item -Path "komocli_${version}_${os}_${arch}.exe"
-Write-Host "komocli installation completed!"
+#Write-Host "Installing komocli..."
+#Move-Item -Path "komocli.exe" -Destination $env:APPDATA
+#Remove-Item -Path "komocli_${version}_${os}_${arch}.exe"
+#Write-Host "komocli installation completed!"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -49,12 +49,8 @@ Write-Host $os
 Write-Host $arch
 Write-Host $downloadURL
 Write-Host "Downloading komocli package..."
-Invoke-WebRequest -Uri $downloadURL -OutFile "komocli_${version}_${os}_${arch}.tar.gz"
-
-Write-Host "Extracting komocli package..."
-tar -xf komocli_${version}_${os}_${arch}.tar.gz
-
+Invoke-WebRequest -Uri $downloadURL -OutFile "komocli_${version}_${os}_${arch}.exe"
 Write-Host "Installing komocli..."
 Move-Item -Path "komocli.exe" -Destination $env:APPDATA
-Remove-Item -Path "komocli_${version}_${os}_${arch}.tar.gz"
+Remove-Item -Path "komocli_${version}_${os}_${arch}.exe"
 Write-Host "komocli installation completed!"


### PR DESCRIPTION
Yossi recently changed that the binary will be downloaded as a binary and not as a tar.gz
Providing an update for the Powershell script so Windows users will be able to install the komocli utility
This was raised by a user from xm-cyber (provided a workaround with that branch)

I validated it works on a Windows machine, @YadgarYossi would appreciate if you could validate it as well.